### PR TITLE
fix: Increase postgres health check retries

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,7 +17,8 @@ services:
       test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER} -d ${POSTGRES_DB}"]
       interval: 2s
       timeout: 5s
-      retries: 3
+      retries: 12
+      start_period: 1s
 
   # port 6379
   redis:


### PR DESCRIPTION
A minimal change so Postgres doesn’t show “unhealthy” prematurely. Instead of a long start_period, keep start_period very low 1s and raise retries (12) so fast machines don’t wait unnecessarily.