### PR TITLE
Refactor os.path to pathlib

### DIFF
--- a/app/routes/static.py
+++ b/app/routes/static.py
@@ -19,8 +19,8 @@ There are some nuances we need to consider:
 """
 
 import mimetypes
-import os
 import re
+from pathlib import Path
 
 from fastapi import FastAPI
 from fastapi.responses import FileResponse
@@ -113,7 +113,7 @@ class GZipStaticFiles(StaticFiles):
                 gz_path = full_path + ".gz"
 
                 # not all assets have a gzip version
-                if os.path.exists(gz_path):
+                if Path(gz_path).exists():
                     content_type, _ = mimetypes.guess_type(full_path)
                     headers = GZIP_HEADERS.copy()
 
@@ -142,7 +142,7 @@ class GZipStaticFiles(StaticFiles):
         We detect this 8 character hash in the file name"
         """
 
-        filename = os.path.basename(path)
+        filename = Path(path).name
         return bool(VITE_HASH_PATTERN.match(filename))
 
 

--- a/tests/direnv.py
+++ b/tests/direnv.py
@@ -18,6 +18,7 @@ import shutil
 import subprocess
 import sys
 import typing as t
+from pathlib import Path
 
 from .constants import TMP_DIRECTORY
 from .log import log
@@ -75,7 +76,7 @@ def direnv_state_sha() -> str:
     if len(env_files) <= 1:
         raise ValueError("No env files found")
 
-    mtimes = "".join(str(os.path.getmtime(f)) for f in env_files)
+    mtimes = "".join(str(Path(f).stat().st_mtime) for f in env_files)
     sha = hashlib.sha256(mtimes.encode()).hexdigest()
 
     log.info("env files inspected for direnv state", env_files=env_files)


### PR DESCRIPTION
Replaced `os.path` usages with `pathlib.Path` in `app/routes/static.py`, `tests/direnv.py`, and `tests/integration/javascript_build.py`. Leveraged Python 3.12+ `Path.walk()` as the project requires Python 3.14+. Verified with custom test scripts.

---
*PR created automatically by Jules for task [844694836752229364](https://jules.google.com/task/844694836752229364) started by @iloveitaly*