### PR TITLE
Add xdist and parallel test execution for Python non-integration tests

### DIFF
--- a/just/python.just
+++ b/just/python.just
@@ -161,12 +161,12 @@ py_test:
 		just _banner_echo "Building Javascript for Integration Tests"
 		just py_js-build
 		just _banner_echo "Running Non-Integration Tests"
-		uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_COV_PARAMS}}
+		uv run pytest . --verbosity=2 --ignore tests/integration -n auto {{PYTEST_COV_PARAMS}}
 		just _banner_echo "Running Integration"
 		uv run pytest tests/integration --verbosity=2 --cov-append {{PYTEST_COV_PARAMS}}
 	else
 		# when not running in CI, JS is built automatically
-		{{EXECUTE_IN_TEST}} uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_COV_PARAMS}}
+		{{EXECUTE_IN_TEST}} uv run pytest . --verbosity=2 --ignore tests/integration -n auto {{PYTEST_COV_PARAMS}}
 		{{EXECUTE_IN_TEST}} uv run pytest tests/integration --verbosity=2 --cov-append {{PYTEST_COV_PARAMS}}
 	fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ dev = [
     "react-router-routes>=0.4.0",
     "pytest-playwright-artifacts>=0.1.0",
     "pytest-line-runner>=0.1.0",
+    "pytest-xdist>=3.8.0",
 ]
 
 # this configuration is VERY important! Without this `--no-editable` flag when building for production will

--- a/tests/concurrent_tests.py
+++ b/tests/concurrent_tests.py
@@ -1,0 +1,126 @@
+import os
+
+from sqlalchemy.engine import make_url
+
+from .log import log
+
+
+def get_worker_database_name(worker_id: str | int) -> str:
+    """
+    Generate a unique, easily identifiable database name for a given pytest-xdist worker.
+    """
+    if isinstance(worker_id, str) and worker_id.startswith("gw"):
+        worker_num = worker_id.replace("gw", "")
+    else:
+        worker_num = str(worker_id)
+
+    return f"pytest_worker_{worker_num}_test"
+
+
+def configure_xdist_worker_environment() -> None:
+    """
+    Configures the environment for xdist workers *before* any other imports or setup.
+    This ensures that when the app is initialized, it connects to the correct database and redis instance.
+    """
+    worker_id_env = os.getenv("PYTEST_XDIST_WORKER")
+    if not worker_id_env:
+        return
+
+    from app.env import env  # Import here to avoid circularity if imported early
+
+    worker_db_name = get_worker_database_name(worker_id_env)
+    worker_num = int(worker_id_env.replace("gw", ""))
+
+    # Configure unique database for this worker
+    original_db_url_str = env.str("TEST_DATABASE_URL")
+    original_db_url = make_url(original_db_url_str)
+
+    # We must modify os.environ directly because app.env.env reads from it
+    # AND we must do it before app.models is imported
+    worker_db_url = original_db_url.set(database=worker_db_name)
+    os.environ["TEST_DATABASE_URL"] = worker_db_url.render_as_string(hide_password=False)
+
+    # Configure unique redis for this worker
+    # Each worker gets its own redis database index to avoid collisions
+    # Redis supports 16 databases by default (0-15)
+    # We'll use 2+ to avoid conflict with default test db (1) and potential others
+    # Assuming max 8 workers, this gives us range 2-9
+    worker_redis_db = str(2 + worker_num)
+
+    original_redis_url_str = env.str("TEST_REDIS_URL")
+
+    # Redis URL parsing. make_url doesn't natively fully support redis database index nicely as the database,
+    # but it works well enough since the database is just the path part.
+    original_redis_url = make_url(original_redis_url_str)
+    worker_redis_url = original_redis_url.set(database=worker_redis_db)
+
+    os.environ["TEST_REDIS_URL"] = worker_redis_url.render_as_string(hide_password=False)
+
+    log.info(
+        "configured xdist worker environment",
+        worker_id=worker_id_env,
+        db_url=os.environ["TEST_DATABASE_URL"],
+        redis_db=os.environ["TEST_REDIS_URL"]
+    )
+
+
+def setup_xdist_worker_databases(num_processes: int | str) -> None:
+    """
+    Create the template databases for the workers to use. This expects to be run in the master
+    pytest process, after the primary `test` database has been fully initialized/migrated/truncated.
+    """
+
+    # If config.option.numprocesses exists, xdist has likely already evaluated "auto" to an integer.
+    # If not, we can safely fall back to logical cpu count.
+    if isinstance(num_processes, int):
+        count = num_processes
+    else:
+        count = os.cpu_count() or 4
+
+    log.info("preparing xdist worker databases", worker_count=count)
+
+    from activemodel.session_manager import get_engine
+    from sqlalchemy import create_engine, text
+
+    engine = get_engine()
+    current_db = engine.url.database
+
+    # Explicitly ensure connections are released before creating template databases
+    # since postgres will fail if there are any active connections to the template DB
+    engine.dispose()
+
+    # Connect specifically to the default 'postgres' database to perform operations on the test db
+    # Doing this avoids active connections on the template database itself
+    postgres_db_url = engine.url.set(database='postgres').render_as_string(hide_password=False)
+    postgres_engine = create_engine(postgres_db_url, isolation_level="AUTOCOMMIT")
+
+    try:
+        with postgres_engine.connect() as conn:
+            # Terminate any remaining connections to the template database
+            conn.execute(text(f"""
+                SELECT pg_terminate_backend(pg_stat_activity.pid)
+                FROM pg_stat_activity
+                WHERE pg_stat_activity.datname = '{current_db}'
+                  AND pid <> pg_backend_pid();
+            """))
+
+            for i in range(count):
+                worker_db_name = get_worker_database_name(i)
+
+                # Drop if exists, disconnecting existing sessions
+                conn.execute(text(f"""
+                    SELECT pg_terminate_backend(pg_stat_activity.pid)
+                    FROM pg_stat_activity
+                    WHERE pg_stat_activity.datname = '{worker_db_name}'
+                      AND pid <> pg_backend_pid();
+                """))
+                conn.execute(text(f"DROP DATABASE IF EXISTS {worker_db_name}"))
+
+                # Create from template of the main test db
+                log.info("creating worker database", worker_db=worker_db_name, template=current_db)
+                conn.execute(text(f"CREATE DATABASE {worker_db_name} WITH TEMPLATE {current_db}"))
+    except Exception as e:
+        log.error("Failed to setup xdist databases", error=str(e))
+        raise e
+    finally:
+        postgres_engine.dispose()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,12 @@ from activemodel.pytest import database_reset_transaction, database_reset_trunca
 from pytest import Config, FixtureRequest
 from app.env import env
 
+from tests.concurrent_tests import configure_xdist_worker_environment, setup_xdist_worker_databases
+
+# Configure environment for xdist workers *before* any other imports or setup
+# This ensures that when the app is initialized, it connects to the correct database
+configure_xdist_worker_environment()
+
 # important to ensure model metadata is added to the application
 import app.models  # noqa: F401
 from app.celery import celery_app
@@ -149,6 +155,11 @@ def pytest_configure(config: Config):
 
 def pytest_sessionstart(session):
     "only executes once if a test is run, at the beginning of the test suite execution"
+
+    # Only run global cleanup in the master process, not in xdist workers
+    if hasattr(session.config, "workerinput"):
+        return
+
     from .utils import delete_all_clerk_users
 
     # without this, the clerk dev instance will get cluttered and throw errors
@@ -156,6 +167,13 @@ def pytest_sessionstart(session):
 
     # clear out any previous cruft in this DB, which is why...
     database_reset_truncate(pytest_config=session.config)
+
+    # Handle xdist worker database setup if we're running with xdist
+    # config.option.numprocesses is set by -n/--numprocesses
+    num_processes = getattr(session.config.option, "numprocesses", None)
+
+    if num_processes:
+        setup_xdist_worker_databases(num_processes)
 
 
 @pytest.fixture(scope="function")

--- a/uv.lock
+++ b/uv.lock
@@ -830,6 +830,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2587,6 +2596,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-crfsuite"
 version = "0.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -2769,6 +2791,7 @@ dev = [
     { name = "pytest-playwright-artifacts" },
     { name = "pytest-playwright-visual-snapshot" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "react-router-routes" },
     { name = "ruff" },
     { name = "squawk-cli" },
@@ -2873,6 +2896,7 @@ dev = [
     { name = "pytest-playwright-artifacts", git = "https://github.com/iloveitaly/pytest-playwright-artifacts.git" },
     { name = "pytest-playwright-visual-snapshot" },
     { name = "pytest-sugar", specifier = ">=1.0.0" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "react-router-routes", specifier = ">=0.4.0" },
     { name = "ruff", specifier = ">=0.7.1" },
     { name = "squawk-cli", specifier = ">=2.33.2" },


### PR DESCRIPTION
I have added `pytest-xdist` to the project to run python non-integration tests in parallel. The changes configure each test worker to have its own unique PostgreSQL database and Redis database index to avoid collisions. The master test process handles test setup logic like truncating the seed database and cloning it for each worker.

---
*PR created automatically by Jules for task [13717195786142027270](https://jules.google.com/task/13717195786142027270) started by @iloveitaly*