### PR TITLE
fix: run Cursor environment install with sudo

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,3 +1,3 @@
 {
-  "install": "curl -fsSL https://raw.githubusercontent.com/iloveitaly/agent-containers/master/cursor/install.sh | bash"
+  "install": "curl -fsSL https://raw.githubusercontent.com/iloveitaly/agent-containers/master/cursor/install.sh | sudo bash"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Cursor cloud agent environment setup was failing because the install script could not write `/etc/apt/keyrings/docker.gpg` without root privileges.

## Description

Update `.cursor/environment.json` so the agent-containers install script is piped to `sudo bash` instead of `bash`.

Verified by re-running the install command with `sudo`; it completed successfully and installed Docker, mise, and direnv.

## Screenshots / Test

N/A — install script verification in the cloud agent environment.

## Links

- Install script: https://raw.githubusercontent.com/iloveitaly/agent-containers/master/cursor/install.sh

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98eac22f-dcf7-4848-9c25-488087ac5553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98eac22f-dcf7-4848-9c25-488087ac5553"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

