### PR TITLE
build(ci): use direct apt-get install and cache playwright browsers

### DIFF
--- a/.github/actions/common-setup/action.yml
+++ b/.github/actions/common-setup/action.yml
@@ -11,11 +11,10 @@ runs:
       with:
         version: 2026.7.18
     # TODO document: https://github.com/actions/runner-images/issues/4849, https://github.com/actions/runner-images/issues/264
-    - uses: tecolicom/actions-use-apt-tools@v1
-      with:
-        # there is not a backend for zsh in mise, crazy!
-        # libnss3-tools is needed for localias to generate certs
-        tools: zsh libnss3-tools
+    # there is not a backend for zsh in mise, crazy!
+    # libnss3-tools is needed for localias to generate certs
+    - shell: bash
+      run: sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh libnss3-tools
     # host config needs to be generated first, before direnv, then localias can be setup
     - shell: bash
       run: just dev_generate_hosts

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -66,6 +66,13 @@ jobs:
         with:
           chrome: true
       - run: just docker_up --fast
+      - name: Cache Playwright Browsers
+        uses: actions/cache@v6
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-${{ hashFiles('uv.lock', '.service-versions') }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
       - run: just py_setup
       - run: just py_lint
       - run: just db_migrate

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -69,7 +69,7 @@ jobs:
       - name: Cache Playwright Browsers
         uses: actions/cache@v6
         with:
-          path: ~/.cache/ms-playwright
+          path: ${{ env.PLAYWRIGHT_BROWSERS_PATH }}
           key: ${{ runner.os }}-playwright-${{ hashFiles('uv.lock', '.service-versions') }}
           restore-keys: |
             ${{ runner.os }}-playwright-


### PR DESCRIPTION
## Motivation

- `tecolicom/actions-use-apt-tools@v1` internally wraps `actions/cache@v4` which targets the deprecated Node.js 20 runtime, triggering GitHub Actions runner deprecation warnings.
- Playwright headless shell download in the Backend CI job (~114MB) was executed unconditionally on every run and can be cached.

## Description

- In `.github/actions/common-setup/action.yml`, replaced `tecolicom/actions-use-apt-tools@v1` with direct `sudo apt-get update && sudo apt-get install -y --no-install-recommends zsh libnss3-tools`.
- In `.github/workflows/build_and_publish.yml`, added `actions/cache@v6` for `~/.cache/ms-playwright` before `just py_setup` in the Backend (`app`) job, keyed against `uv.lock` and `.service-versions`.

## Screenshots / Test

- Linting and configuration verified via `just dev_lint`.