### PR TITLE
ci: disable image publish job pending railpack switch

### DIFF
--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -109,12 +109,14 @@ jobs:
       - run: just js_lint
       - run: just js_test
 
+  # NOTE disabled for now; we are going to switch to railpack soon
+  # https://railpack.com/guides/running-railpack-in-production
   deploy:
     name: 🚀 Deploy
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [web, app]
-    if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
+    if: false
     permissions:
       packages: write
       contents: read

--- a/.github/workflows/build_and_publish.yml
+++ b/.github/workflows/build_and_publish.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     needs: [web, app]
+    # if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
     if: false
     permissions:
       packages: write


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Temporarily stop publishing production images from GitHub Actions. The current deploy path is nixpacks-based, and we are going to switch to [railpack](https://railpack.com/guides/running-railpack-in-production) soon.

## Description

The `deploy` job in `.github/workflows/build_and_publish.yml` is skipped with `if: false`. The previous master-push condition is left as a comment so it is easy to restore:

```yaml
# if: ${{ github.ref == 'refs/heads/master' && github.event_name == 'push' }}
if: false
```

Backend and frontend CI jobs still run on push and pull request. The job definition stays in the file so it is easy to replace with a railpack-based publish later.

## Screenshots / Test

Latest CI: Backend success, Frontend success, Deploy skipped.
https://github.com/iloveitaly/python-starter-template/actions/runs/33431001449

## Links

- https://railpack.com/guides/running-railpack-in-production

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b79bd807-8e18-497f-8fd6-e6e62950191b?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b79bd807-8e18-497f-8fd6-e6e62950191b&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

