### PR TITLE
Add pytest-xdist for non-integration tests

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,6 +31,8 @@ services:
     # NOTE you'll probably need to drop this value for your production environment which will lag edge releases
     image: redis:8
     restart: unless-stopped
+    # default is 16; pytest-xdist workers each get a dedicated logical db
+    command: ["redis-server", "--databases", "128"]
     ports:
       - ${CI:+6379}:6379
     healthcheck:

--- a/just/python.just
+++ b/just/python.just
@@ -150,6 +150,8 @@ py_js-build:
 	export PNPM_GLOBAL_FLAGS="--silent" && {{EXECUTE_IN_TEST}} just js_build
 
 PYTEST_COV_PARAMS := "--cov --cov-report=html:${TEST_RESULTS_DIRECTORY}/htmlcov"
+# integration tests share a live server/browser and are not xdist-safe
+PYTEST_XDIST_PARAMS := "-n auto --dist loadgroup"
 
 # run tests with the exact same environment that will be used on CI
 [script]
@@ -167,12 +169,12 @@ py_test:
 		just _banner_echo "Building Javascript for Integration Tests"
 		just py_js-build
 		just _banner_echo "Running Non-Integration Tests"
-		uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_COV_PARAMS}}
+		uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_XDIST_PARAMS}} {{PYTEST_COV_PARAMS}}
 		just _banner_echo "Running Integration"
 		uv run pytest tests/integration --verbosity=2 --cov-append {{PYTEST_COV_PARAMS}}
 	else
 		# when not running in CI, JS is built automatically
-		{{EXECUTE_IN_TEST}} uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_COV_PARAMS}}
+		{{EXECUTE_IN_TEST}} uv run pytest . --verbosity=2 --ignore tests/integration {{PYTEST_XDIST_PARAMS}} {{PYTEST_COV_PARAMS}}
 		{{EXECUTE_IN_TEST}} uv run pytest tests/integration --verbosity=2 --cov-append {{PYTEST_COV_PARAMS}}
 	fi
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ dev = [
     "react-router-routes>=0.4.2",
     "pytest-playwright-artifacts>=0.4.0",
     "pytest-line-runner>=0.1.0",
+    "pytest-xdist>=3.8.0",
     "faker>=40.36.0",
     "alembic-squawk>=0.2.0",
     "truststore>=0.10.4",

--- a/pytest.toml
+++ b/pytest.toml
@@ -1,4 +1,6 @@
 [pytest]
+# pytest-xdist is enabled by `just py_test` for non-integration tests only
+# (`-n auto --dist loadgroup`). Integration tests stay serial.
 addopts = [
     # disable all of default log capture: structlog does this for us
     "-p no:logging",

--- a/tests/concurrent_tests.py
+++ b/tests/concurrent_tests.py
@@ -4,8 +4,6 @@
 so worker URLs must be rewritten before any `app` import.
 """
 
-from __future__ import annotations
-
 import os
 import re
 from urllib.parse import urlparse, urlunparse

--- a/tests/concurrent_tests.py
+++ b/tests/concurrent_tests.py
@@ -1,0 +1,144 @@
+"""Isolate pytest-xdist workers onto their own Postgres and Redis databases.
+
+`app.setup()` reads `TEST_DATABASE_URL` / `TEST_REDIS_URL` and connects immediately,
+so worker URLs must be rewritten before any `app` import.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from urllib.parse import urlparse, urlunparse
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection
+
+from .log import log
+
+WORKER_ID_PATTERN = re.compile(r"^gw(\d+)$")
+WORKER_DATABASE_NAME_PATTERN = re.compile(r"^test_xdist_\d+$")
+
+# Redis db 0 unused, db 1 development, db 2 default test / worker gw0.
+# docker-compose redis is started with `--databases 128` to leave headroom for workers.
+REDIS_DB_OFFSET = 2
+REDIS_DATABASE_COUNT = 128
+
+
+def xdist_worker_id() -> str | None:
+    return os.environ.get("PYTEST_XDIST_WORKER")
+
+
+def worker_index(worker_id: str) -> int:
+    match = WORKER_ID_PATTERN.fullmatch(worker_id)
+    assert match, f"unexpected pytest-xdist worker id: {worker_id}"
+    return int(match.group(1))
+
+
+def worker_database_name(index: int) -> str:
+    assert index >= 0
+    name = f"test_xdist_{index}"
+    assert WORKER_DATABASE_NAME_PATTERN.fullmatch(name)
+    return name
+
+
+def replace_url_path(url: str, path: str) -> str:
+    parsed = urlparse(url)
+    return urlunparse(parsed._replace(path=f"/{path}"))
+
+
+def configure_xdist_worker_environment() -> None:
+    worker_id = xdist_worker_id()
+    if not worker_id:
+        return
+
+    index = worker_index(worker_id)
+    redis_db = REDIS_DB_OFFSET + index
+    assert redis_db < REDIS_DATABASE_COUNT, (
+        f"xdist worker {index} needs redis db {redis_db}; "
+        f"increase redis --databases (currently {REDIS_DATABASE_COUNT})"
+    )
+
+    os.environ["TEST_DATABASE_URL"] = replace_url_path(
+        os.environ["TEST_DATABASE_URL"],
+        worker_database_name(index),
+    )
+    os.environ["TEST_REDIS_URL"] = replace_url_path(
+        os.environ["TEST_REDIS_URL"],
+        str(redis_db),
+    )
+
+    log.info(
+        "configured xdist worker environment",
+        worker_id=worker_id,
+        test_database_url=os.environ["TEST_DATABASE_URL"],
+        test_redis_url=os.environ["TEST_REDIS_URL"],
+    )
+
+
+def setup_xdist_worker_databases(worker_count: int) -> None:
+    """Clone the truncated test database for each xdist worker.
+
+    Must run on the controller before workers start: `CREATE DATABASE ... TEMPLATE`
+    cannot run concurrently against the same source database.
+    """
+    assert worker_count > 0
+
+    from activemodel.session_manager import get_engine
+
+    engine = get_engine()
+    template_db = engine.url.database
+    assert template_db
+
+    engine.dispose()
+
+    postgres_engine = create_engine(
+        engine.url.set(database="postgres"),
+        isolation_level="AUTOCOMMIT",
+    )
+
+    try:
+        with postgres_engine.connect() as conn:
+            _terminate_connections(conn, template_db)
+            _drop_existing_xdist_databases(conn)
+
+            for index in range(worker_count):
+                name = worker_database_name(index)
+                log.info(
+                    "creating worker database",
+                    worker_db=name,
+                    template=template_db,
+                )
+                conn.execute(
+                    text(f'CREATE DATABASE "{name}" WITH TEMPLATE "{template_db}"')
+                )
+    finally:
+        postgres_engine.dispose()
+
+
+def _terminate_connections(conn: Connection, database_name: str) -> None:
+    conn.execute(
+        text(
+            """
+            SELECT pg_terminate_backend(pid)
+            FROM pg_stat_activity
+            WHERE datname = :database_name
+              AND pid <> pg_backend_pid()
+            """
+        ),
+        {"database_name": database_name},
+    )
+
+
+def _drop_existing_xdist_databases(conn: Connection) -> None:
+    names = list(
+        conn.execute(
+            text(
+                "SELECT datname FROM pg_database WHERE datname ~ '^test_xdist_[0-9]+$'"
+            )
+        ).scalars()
+    )
+
+    for name in names:
+        assert WORKER_DATABASE_NAME_PATTERN.fullmatch(name)
+        _terminate_connections(conn, name)
+        conn.execute(text(f'DROP DATABASE IF EXISTS "{name}"'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,6 +38,16 @@ if os.getenv("PYTHON_ENV", "development") != "test":
 
     load_ci_environment()
 
+from tests.concurrent_tests import (
+    configure_xdist_worker_environment,
+    setup_xdist_worker_databases,
+    xdist_worker_id,
+)
+
+# app.setup() binds the DB/Redis URLs at import time, so workers must rewrite
+# TEST_* URLs before any `app` import.
+configure_xdist_worker_environment()
+
 import multiprocessing
 from pathlib import Path
 import stripe
@@ -112,7 +122,10 @@ def pytest_configure(config: Config):
     # config.option.log_cli_level = "INFO"
 
     # lower debug level for file debugging, so we can download this artifact and view detailed debugging
-    config.option.log_file = str(TEST_RESULTS_DIRECTORY / "pytest.log")
+    log_name = "pytest.log"
+    if worker_id := xdist_worker_id():
+        log_name = f"pytest-{worker_id}.log"
+    config.option.log_file = str(TEST_RESULTS_DIRECTORY / log_name)
     # config.option.log_file_level = "DEBUG"
 
     config.option.enable_beautiful_traceback = True
@@ -152,6 +165,11 @@ def pytest_configure(config: Config):
 
 def pytest_sessionstart(session):
     "only executes once if a test is run, at the beginning of the test suite execution"
+
+    # workers use cloned databases prepared by pytest_xdist_setupnodes
+    if xdist_worker_id():
+        return
+
     from .utils import delete_all_clerk_users
 
     # without this, the clerk dev instance will get cluttered and throw errors
@@ -159,6 +177,14 @@ def pytest_sessionstart(session):
 
     # clear out any previous cruft in this DB, which is why...
     database_reset_truncate(pytest_config=session.config)
+
+
+def pytest_xdist_setupnodes(config, specs):
+    """Clone the truncated test DB for each worker before xdist starts them.
+
+    xdist's sessionstart is trylast, so pytest_sessionstart has already truncated.
+    """
+    setup_xdist_worker_databases(len(specs))
 
 
 @pytest.fixture(scope="function")
@@ -260,7 +286,18 @@ def httpx2_breakpoint(httpx2_mock):
     return httpx2_mock
 
 
-def pytest_collection_modifyitems(items):
+def pytest_collection_modifyitems(config: Config, items):
+    xdist_active = bool(
+        xdist_worker_id() or getattr(config.option, "numprocesses", None)
+    )
+    if xdist_active:
+        integration_tests = Path(__file__).parent / "integration"
+        if any(item.path.is_relative_to(integration_tests) for item in items):
+            raise pytest.UsageError(
+                "pytest-xdist cannot run integration tests; "
+                "drop -n or pass --ignore tests/integration"
+            )
+
     for item in items:
         if "httpx2_breakpoint" not in item.fixturenames:
             continue

--- a/tests/unit/concurrent_tests_test.py
+++ b/tests/unit/concurrent_tests_test.py
@@ -1,0 +1,72 @@
+import os
+
+import pytest
+
+from tests.concurrent_tests import (
+    REDIS_DB_OFFSET,
+    configure_xdist_worker_environment,
+    replace_url_path,
+    worker_database_name,
+    worker_index,
+)
+
+
+def test_worker_index_parses_gateway_id():
+    assert worker_index("gw0") == 0
+    assert worker_index("gw12") == 12
+
+
+def test_worker_index_rejects_unexpected_ids():
+    with pytest.raises(AssertionError, match="unexpected pytest-xdist worker id"):
+        worker_index("master")
+
+
+def test_worker_database_name():
+    assert worker_database_name(0) == "test_xdist_0"
+    assert worker_database_name(7) == "test_xdist_7"
+
+
+def test_replace_url_path_rewrites_postgres_and_redis():
+    assert (
+        replace_url_path(
+            "postgresql://root:password@localhost:5432/test", "test_xdist_3"
+        )
+        == "postgresql://root:password@localhost:5432/test_xdist_3"
+    )
+    assert (
+        replace_url_path("redis://localhost:6379/2", "5") == "redis://localhost:6379/5"
+    )
+
+
+def test_configure_xdist_worker_environment_is_noop_without_worker(monkeypatch):
+    monkeypatch.delenv("PYTEST_XDIST_WORKER", raising=False)
+    monkeypatch.setenv(
+        "TEST_DATABASE_URL", "postgresql://root:password@localhost:5432/test"
+    )
+    monkeypatch.setenv("TEST_REDIS_URL", "redis://localhost:6379/2")
+
+    configure_xdist_worker_environment()
+
+    assert (
+        os.environ["TEST_DATABASE_URL"]
+        == "postgresql://root:password@localhost:5432/test"
+    )
+    assert os.environ["TEST_REDIS_URL"] == "redis://localhost:6379/2"
+
+
+def test_configure_xdist_worker_environment_rewrites_urls(monkeypatch):
+    monkeypatch.setenv("PYTEST_XDIST_WORKER", "gw3")
+    monkeypatch.setenv(
+        "TEST_DATABASE_URL", "postgresql://root:password@localhost:5432/test"
+    )
+    monkeypatch.setenv("TEST_REDIS_URL", "redis://localhost:6379/2")
+
+    configure_xdist_worker_environment()
+
+    assert (
+        os.environ["TEST_DATABASE_URL"]
+        == "postgresql://root:password@localhost:5432/test_xdist_3"
+    )
+    assert (
+        os.environ["TEST_REDIS_URL"] == f"redis://localhost:6379/{REDIS_DB_OFFSET + 3}"
+    )

--- a/tests/unit/generated_test.py
+++ b/tests/unit/generated_test.py
@@ -7,6 +7,9 @@ from app.generated import fastapi_typed_routes, react_router_routes
 
 from tests.direnv import run_just_recipe
 
+# these tests rewrite generated files; keep them on one worker
+pytestmark = pytest.mark.xdist_group("generated_files")
+
 
 def test_openapi_schema_matches_generated_file():
     # NOTE this is not set anywhere in the py codebase, which is why we need to manually source it here

--- a/uv.lock
+++ b/uv.lock
@@ -1010,6 +1010,15 @@ wheels = [
 ]
 
 [[package]]
+name = "execnet"
+version = "2.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/89/780e11f9588d9e7128a3f87788354c7946a9cbb1401ad38a48c4db9a4f07/execnet-2.1.2.tar.gz", hash = "sha256:63d83bfdd9a23e35b9c6a3261412324f964c2ec8dcd8d3c6916ee9373e0befcd", size = 166622, upload-time = "2025-11-12T09:56:37.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ab/84/02fc1827e8cdded4aa65baef11296a9bbe595c474f0d6d758af082d849fd/execnet-2.1.2-py3-none-any.whl", hash = "sha256:67fba928dd5a544b783f6056f449e5e3931a5c378b128bc18501f7ea79e296ec", size = 40708, upload-time = "2025-11-12T09:56:36.333Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2925,6 +2934,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-xdist"
+version = "3.8.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "execnet" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/78/b4/439b179d1ff526791eb921115fca8e44e596a13efeda518b9d845a619450/pytest_xdist-3.8.0.tar.gz", hash = "sha256:7e578125ec9bc6050861aa93f2d59f1d8d085595d6551c2c90b6f4fad8d3a9f1", size = 88069, upload-time = "2025-07-01T13:30:59.346Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/31/d4e37e9e550c2b92a9cbc2e4d0b7420a27224968580b5a447f420847c975/pytest_xdist-3.8.0-py3-none-any.whl", hash = "sha256:202ca578cfeb7370784a8c33d6d05bc6e13b4f25b5053c30a152269fd10f0b88", size = 46396, upload-time = "2025-07-01T13:30:56.632Z" },
+]
+
+[[package]]
 name = "python-crfsuite"
 version = "0.9.12"
 source = { registry = "https://pypi.org/simple" }
@@ -3120,6 +3142,7 @@ dev = [
     { name = "pytest-playwright-artifacts" },
     { name = "pytest-playwright-visual-snapshot" },
     { name = "pytest-sugar" },
+    { name = "pytest-xdist" },
     { name = "react-router-routes" },
     { name = "ruff" },
     { name = "squawk-cli" },
@@ -3234,6 +3257,7 @@ dev = [
     { name = "pytest-playwright-artifacts", git = "https://github.com/iloveitaly/pytest-playwright-artifacts.git" },
     { name = "pytest-playwright-visual-snapshot", git = "https://github.com/iloveitaly/pytest-playwright-visual-snapshot.git" },
     { name = "pytest-sugar", specifier = ">=1.1.1" },
+    { name = "pytest-xdist", specifier = ">=3.8.0" },
     { name = "react-router-routes", specifier = ">=0.4.2" },
     { name = "ruff", specifier = ">=0.16.1" },
     { name = "squawk-cli", specifier = ">=2.62.0" },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

Non-integration tests are independent enough to run in parallel, but the suite currently executes them serially. `pytest-xdist` should cut that wall-clock time, especially on CI.

A previous attempt (#61) rewrote worker database URLs *after* `app` was imported. `app.setup()` already binds Postgres and Redis at import time, so every worker still shared the main test database.

Integration tests stay serial: they share a live server, browser, and truncation-based DB reset.

## Description

- Add `pytest-xdist` and run non-integration tests with `-n auto --dist loadgroup` from `just py_test`.
- Rewrite `TEST_DATABASE_URL` / `TEST_REDIS_URL` in each worker **before** any `app` import.
- On the controller, truncate the template test DB, then `CREATE DATABASE ... TEMPLATE` one clone per worker (`test_xdist_N`).
- Give Redis `--databases 128` so workers can `FLUSHDB` without colliding (db 2+N).
- Keep generated-file tests on a single worker via `xdist_group`.
- Fail collection if xdist is combined with `tests/integration`.

## Screenshots / Test

Non-integration tests: `just py_test` (xdist on). Integration tests remain a separate serial pytest invocation.

## Links

- Closed predecessor: #61
- pytest-xdist: https://pytest-xdist.readthedocs.io/
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9a129be0-7c9b-4381-a21c-220fc349950a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9a129be0-7c9b-4381-a21c-220fc349950a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

