### PR TITLE
chore(posthog): drop new_context capture_exceptions workaround

### DIFF
--- a/app/configuration/posthog.py
+++ b/app/configuration/posthog.py
@@ -23,8 +23,8 @@ posthog_client = posthog.Posthog(
 if not is_production():
     posthog_client.disabled = True
 
-# https://github.com/PostHog/posthog-python/issues/353
-# without this, a newly-created client will be used for things like catching context exceptions
+# Module-level APIs (`posthog.new_context`, `posthog.capture`, …) use this client.
+# Without it, contexts fall back to a separately constructed default instance.
 posthog.default_client = posthog_client
 
 

--- a/app/routes/dependencies/posthog.py
+++ b/app/routes/dependencies/posthog.py
@@ -22,7 +22,7 @@ async def inject_posthog_identity(request: Request):
     > If two users have the same distinct ID, their data is merged and they are considered one user in PostHog.
     """
 
-    with posthog.new_context(capture_exceptions=False):
+    with posthog.new_context():
         # by using clerk_id, we can easily use the same UUID on frontend events
         posthog.identify_context(request.state.user.clerk_id)
         yield
@@ -42,8 +42,7 @@ async def inject_posthog_tags(request: Request):
     """
 
     # by default, there is not a context, so we must define one
-    # `capture_exceptions=False` https://github.com/PostHog/posthog-python/issues/353
-    with posthog.new_context(capture_exceptions=False):
+    with posthog.new_context():
         # intentionally overwrite any other session or distinct id set previously
         # it's up to the user to add dependencies in the correct order
         if distinct_id := request.headers.get("X-Posthog-Distinct-Id"):

--- a/tests/unit/posthog_test.py
+++ b/tests/unit/posthog_test.py
@@ -1,0 +1,19 @@
+import posthog
+import pytest
+
+from app.configuration.posthog import posthog_client
+
+
+def test_default_client_is_the_configured_instance():
+    assert posthog.default_client is posthog_client
+    assert posthog_client.enable_exception_autocapture is False
+
+
+def test_new_context_does_not_capture_exceptions_when_autocapture_is_disabled(mocker):
+    capture = mocker.patch("posthog.capture_exception")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with posthog.new_context():
+            raise RuntimeError("boom")
+
+    capture.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Motivation

[posthog-python#353](https://github.com/PostHog/posthog-python/issues/353) is fixed in [PR #680](https://github.com/PostHog/posthog-python/pull/680): `new_context()` now inherits `enable_exception_autocapture` from the client / default client instead of always capturing exceptions.

This repo already depends on `posthog>=7.38.0` (locked at 7.45.1), which includes that behavior. No extra SDK work is required to "support" the upstream change.

## Description

We had a workaround of passing `capture_exceptions=False` on every `posthog.new_context()` because the SDK ignored the client setting.

That is no longer needed. `enable_exception_autocapture=False` on the configured client is enough.

**Still required:** `posthog.default_client = posthog_client`. Module-level APIs (`posthog.new_context`, `posthog.capture`, …) do not automatically use a separately constructed `Posthog()` instance. Issue #353 also called that out; #680 did not add a different client-assignment API.

## Screenshots / Test

Verified against installed `posthog==7.45.1`:

- `new_context()` with no `capture_exceptions` argument sets `capture_exceptions=False` when the default client has `enable_exception_autocapture=False`
- exceptions inside that context do not call `capture_exception`
- explicit `capture_exceptions=True` still opts in

## Links

- https://github.com/PostHog/posthog-python/issues/353
- https://github.com/PostHog/posthog-python/pull/680

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a31a8a99-5459-4688-9bf3-9fcb4b4c5cef?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a31a8a99-5459-4688-9bf3-9fcb4b4c5cef&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

